### PR TITLE
Allow users to specify the WorkingDirectory for OSX app plist files

### DIFF
--- a/lib/rawr/app_bundler.rb
+++ b/lib/rawr/app_bundler.rb
@@ -12,6 +12,7 @@ module Rawr
       @classpath = options.classpath
       @main_java_class = options.main_java_file
       @built_jar_path = options.jar_output_dir
+      @working_directory = options.mac_plist_working_directory
       
       @mac_path = options.osx_output_dir
       @mac_app_path = "#{@mac_path}/#{@project_name}.app"
@@ -109,6 +110,8 @@ module Rawr
             <array>
                 <string>$JAVAROOT/#{@project_name}.jar</string>
             </array>
+        <key>WorkingDirectory</key>
+            <string>#{@working_directory}</string>
         <key>Properties</key>
         <dict>
             <key>apple.laf.useScreenMenuBar</key>

--- a/lib/rawr/configuration.rb
+++ b/lib/rawr/configuration.rb
@@ -37,6 +37,7 @@ module Rawr
       
       # Platform-specific options
       Option.new(:mac_do_not_generate_plist, false),
+      Option.new(:mac_plist_working_directory, String, '$APP_PACKAGE', "working directory specified in plist file"),
       Option.new(:mac_icon_path, FilePath),
       Option.new(:windows_icon_path, FilePath)
     ]


### PR DESCRIPTION
In my project we rely the working directory to be the same as it is on Windows or when using the JAR (where the *.exe or *.jar file resides)

Since OSX generates .app files this is not the case (the working directory is the directory which contains the .app directory

In our case we rely on it so we can load a static data file (lib/countries.yml) which is specified with the `files_to_copy` option.

I've added a new option `mac_plist_working_directory` which will specify the value WorkingDirectory key in the plist file.  This will default to $APP_PACKAGE which is Apple's default value for this key, which will ensure backwards compatibility.

https://developer.apple.com/library/mac/#documentation/Java/Reference/Java_InfoplistRef/Articles/JavaDictionaryInfo.plistKeys.html
