### PR TITLE
Use ERB for generated configuration files

### DIFF
--- a/lib/rawr/app_bundler.rb
+++ b/lib/rawr/app_bundler.rb
@@ -1,5 +1,6 @@
 require 'fileutils'
 require 'rawr/bundler'
+require 'rawr/bundler_template'
 
 # See http://developer.apple.com/documentation/Java/Reference/Java_InfoplistRef/Articles/JavaDictionaryInfo.plistKeys.html for details
 
@@ -77,55 +78,7 @@ module Rawr
       mac_icon_filename = @mac_icon_path.sub(File.dirname(@mac_icon_path) + '/', '')
 
       File.open "Info.plist", 'w' do |file|
-        file << <<-INFO_ENDL
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist SYSTEM "file://localhost/System/Library/DTDs/PropertyList.dtd">
-<plist version="0.9">
-<dict>
-    <key>CFBundleName</key>
-    <string>#{@project_name}</string>
-    <key>CFBundleVersion</key>
-    <string>100.0</string>
-    <key>CFBundleAllowMixedLocalizations</key>
-    <string>true</string>
-    <key>CFBundleExecutable</key>
-    <string>JavaApplicationStub</string>
-    <key>CFBundleDevelopmentRegion</key>
-    <string>English</string>
-    <key>CFBundlePackageType</key>
-    <string>APPL</string>
-    <key>CFBundleSignature</key>
-    <string>????</string>
-    <key>CFBundleInfoDictionaryVersion</key>
-    <string>6.0</string>
-    <key>CFBundleIconFile</key>
-    <string>#{mac_icon_filename}</string>
-    <key>Java</key>
-    <dict>
-        <key>MainClass</key>
-        <string>#{@main_java_class}</string>
-        <key>JVMVersion</key>
-        <string>#{@target_jvm_version}*</string>
-        <key>ClassPath</key>
-            <array>
-                <string>$JAVAROOT/#{@project_name}.jar</string>
-            </array>
-        <key>WorkingDirectory</key>
-            <string>#{@working_directory}</string>
-        <key>Properties</key>
-        <dict>
-            <key>apple.laf.useScreenMenuBar</key>
-            <string>true</string>
-            #{"<key>java.library.path</key>\n<string>$JAVAROOT/" + @java_library_path + "</string>" unless @java_library_path.nil? || @java_library_path.strip.empty?}
-        </dict>
-        <key>VMOptions</key>
-          <array>
-            #{@jvm_arguments.split(' ').map {|arg| "<string>" + arg + "</string>\n"}}
-          </array>
-    </dict>
-</dict>
-</plist>
-INFO_ENDL
+        file << BundlerTemplate.find('app_bundler', 'Info.plist').result(binding)
       end
     end
   end

--- a/lib/rawr/bundler_template.rb
+++ b/lib/rawr/bundler_template.rb
@@ -1,0 +1,25 @@
+require 'erb'
+
+module Rawr
+   class BundlerTemplate < ERB
+
+      def self.find(bundle_type, template_name)
+         filename = File.join(File.dirname(__FILE__), 'templates', bundle_type, "#{template_name}.erb")
+
+         new(filename)
+      end
+
+      def initialize(filename)
+         # As of JRuby 1.6.7 $SAFE is not supported in ERB, but this shouldn't
+         # matter anyways since any templates loaded should be trusted.
+         #
+         # '>' causes ERB to eat newlines on lines which contain only ERB <% %> 
+         # tags (for pretty output).  This can probably be improved a bit.
+         super(File.read(filename), nil, '>')
+      end
+
+      #TODO: consider providing access to configuration here and adding a 
+      #      render() function, rather than rendering in the Bundle class
+
+   end
+end

--- a/lib/rawr/creator.rb
+++ b/lib/rawr/creator.rb
@@ -1,4 +1,5 @@
 require 'rawr/configuration'
+require 'rawr/bundler_template'
 
 module Rawr
   class Creator
@@ -26,86 +27,7 @@ module Rawr
     
     def self.create_java_main_file java_file, java_package, java_class
       File.open(java_file, "w+") do |java_main_file|
-        java_main_file << <<-ENDL
-package #{java_package};
-
-import java.io.BufferedReader;
-import java.io.InputStreamReader;
-import java.io.InputStream;
-import java.io.IOException;
-import java.net.URL;
-
-
-import java.util.ArrayList;
-import org.jruby.Ruby;
-import org.jruby.RubyInstanceConfig;
-import org.jruby.javasupport.JavaEmbedUtils;
-
-public class #{java_class} {
-  public static void debuggery(String message){
-    System.err.println("DEBUGGERY:" + message); // JGBDEBUG
-    }
-
-  public static void main(String[] args) throws Exception {   
-    RubyInstanceConfig config = new RubyInstanceConfig();
-    config.setArgv(args);
-    Ruby runtime = JavaEmbedUtils.initialize(new ArrayList(0), config);
-    String mainRubyFile  = "main";
-    String runConfigFile = "run_configuration";
-
-    ArrayList<String> config_data = new ArrayList<String>();
-    try{
-      java.io.InputStream ins = Main.class.getClassLoader().getResourceAsStream(runConfigFile);
-      if (ins == null ) {
-        System.err.println("Did not find configuration file '" + runConfigFile + "', using defaults.");
-      } else {
-        config_data = getConfigFileContents(ins);
-      }
-    }
-    catch(IOException ioe) {
-      System.err.println("Error loading run configuration file '" + runConfigFile + "', using defaults: " + ioe);
-    }
-    catch(java.lang.NullPointerException npe) {
-      System.err.println("Error loading run configuration file '" + runConfigFile + "', using defaults: " + npe );
-    }
-
-    for(String line : config_data) {
-
-      String[] parts = line.split(":");
-      if("main_ruby_file".equals(parts[0].replaceAll(" ", ""))) {
-        mainRubyFile = parts[1].replaceAll(" ", "");
-      }
-
-      if("source_dirs".equals(parts[0].replaceAll(" ", ""))) {
-        String[] source_dirs = parts[1].split(";");
-
-        for(String s : parts[1].split(";") ){
-          String d = s.replaceAll(" ", "");
-          runtime.evalScriptlet( "$: << '"+d+"/'" );
-        }
-      }
-    }
-
-    runtime.evalScriptlet("require '" + mainRubyFile + "'");
-  }
-
-  public static URL getResource(String path) {
-      return Main.class.getClassLoader().getResource(path);
-  }
-
-  private static ArrayList<String> getConfigFileContents(InputStream input) throws IOException, java.lang.NullPointerException {
-    BufferedReader reader = new BufferedReader(new InputStreamReader(input));
-    String line;
-    ArrayList<String> contents = new ArrayList<String>();
-
-    while ((line = reader.readLine()) != null) {
-      contents.add(line);
-    }
-    reader.close();
-    return(contents);
-  }
-}
-ENDL
+        java_main_file << BundlerTemplate.find('java_runner', 'runner.java').result(binding)
       end
     end
    

--- a/lib/rawr/exe_bundler.rb
+++ b/lib/rawr/exe_bundler.rb
@@ -2,6 +2,7 @@ require 'fileutils'
 
 require 'rawr/bundler'
 require 'rawr/platform'
+require 'rawr/bundler_template'
 
 module Rawr
   class ExeBundler < Bundler  
@@ -45,34 +46,7 @@ module Rawr
 
       
       File.open(@launch4j_config_file, 'w') do |file|
-        file << <<-CONFIG_ENDL
-<launch4jConfig>
-<dontWrapJar>true</dontWrapJar>
-<headerType>#{@executable_type}</headerType>
-<jar>#{@project_name}.jar</jar>
-<outfile>#{@project_name}.exe</outfile>
-<errTitle></errTitle>
-<jarArgs></jarArgs>
-<chdir></chdir>
-<customProcName>true</customProcName>
-<stayAlive>false</stayAlive>
-<icon>#{@icon_path}</icon>
-<jre>
-  <path></path>
-  <minVersion>#{@minimum_windows_jvm_version}.0</minVersion>
-  <maxVersion></maxVersion>
-  <initialHeapSize>0</initialHeapSize>
-  <maxHeapSize>0</maxHeapSize>
-  <args>#{ @jvm_arguments unless @jvm_arguments.nil? || @jvm_arguments.strip.empty? } #{ "-Djava.library.path=" + @java_library_path unless @java_library_path.nil? || @java_library_path.strip.empty?}</args>
-</jre>
-<messages>
-  <startupErr>#{@startup_error_message}</startupErr>
-  <bundledJreErr>#{@bundled_jre_error_message}</bundledJreErr>
-  <jreVersionErr>#{@jre_version_error_message}</jreVersionErr>
-  <launcherErr>#{@launcher_error_message}</launcherErr>
-</messages>
-</launch4jConfig>          
-CONFIG_ENDL
+        file << BundlerTemplate.find('exe_bundler', 'configuration.xml').result(binding)
       end
 
       file_dir_name = File.dirname(__FILE__)

--- a/lib/rawr/templates/app_bundler/Info.plist.erb
+++ b/lib/rawr/templates/app_bundler/Info.plist.erb
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist SYSTEM "file://localhost/System/Library/DTDs/PropertyList.dtd">
+<plist version="0.9">
+<dict>
+    <key>CFBundleName</key>
+    <string><%= @project_name %></string>
+    <key>CFBundleVersion</key>
+    <string>100.0</string>
+    <key>CFBundleAllowMixedLocalizations</key>
+    <string>true</string>
+    <key>CFBundleExecutable</key>
+    <string>JavaApplicationStub</string>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>English</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleSignature</key>
+    <string>????</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleIconFile</key>
+    <string><%= mac_icon_filename %></string>
+    <key>Java</key>
+    <dict>
+        <key>MainClass</key>
+        <string><%= @main_java_class %></string>
+        <key>JVMVersion</key>
+        <string><%= @target_jvm_version %>*</string>
+        <key>ClassPath</key>
+            <array>
+                <string>$JAVAROOT/<%= @project_name %>.jar</string>
+            </array>
+        <key>WorkingDirectory</key>
+            <string><%= @working_directory %></string>
+        <key>Properties</key>
+        <dict>
+            <key>apple.laf.useScreenMenuBar</key>
+            <string>true</string>
+            <% unless @java_library_path.nil? || @java_library_path.strip.empty? %>
+            <key>java.library.path</key>
+            <string>$JAVAROOT/<%= @java_library_path %></string>
+            <% end %>
+        </dict>
+        <key>VMOptions</key>
+          <array>
+            <% @jvm_arguments.split(' ').each do |arg| %>
+            <string><%= arg %></string>
+            <% end %>
+          </array>
+    </dict>
+</dict>
+</plist>

--- a/lib/rawr/templates/exe_bundler/configuration.xml.erb
+++ b/lib/rawr/templates/exe_bundler/configuration.xml.erb
@@ -1,0 +1,26 @@
+<launch4jConfig>
+<dontWrapJar>true</dontWrapJar>
+<headerType><%= @executable_type %></headerType>
+<jar><%= @project_name %>.jar</jar>
+<outfile><%= @project_name %>.exe</outfile>
+<errTitle></errTitle>
+<jarArgs></jarArgs>
+<chdir></chdir>
+<customProcName>true</customProcName>
+<stayAlive>false</stayAlive>
+<icon><%= @icon_path %></icon>
+<jre>
+  <path></path>
+  <minVersion><%= @minimum_windows_jvm_version %>.0</minVersion>
+  <maxVersion></maxVersion>
+  <initialHeapSize>0</initialHeapSize>
+  <maxHeapSize>0</maxHeapSize>
+  <args><%= @jvm_arguments unless @jvm_arguments.nil? || @jvm_arguments.strip.empty? %> <%= "-Djava.library.path=" + @java_library_path unless @java_library_path.nil? || @java_library_path.strip.empty? %></args>
+</jre>
+<messages>
+  <startupErr><%= @startup_error_message %></startupErr>
+  <bundledJreErr><%= @bundled_jre_error_message %></bundledJreErr>
+  <jreVersionErr><%= @jre_version_error_message %></jreVersionErr>
+  <launcherErr><%= @launcher_error_message %></launcherErr>
+</messages>
+</launch4jConfig> 

--- a/lib/rawr/templates/java_runner/runner.java.erb
+++ b/lib/rawr/templates/java_runner/runner.java.erb
@@ -1,0 +1,78 @@
+package <%= java_package %>;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.io.InputStream;
+import java.io.IOException;
+import java.net.URL;
+
+
+import java.util.ArrayList;
+import org.jruby.Ruby;
+import org.jruby.RubyInstanceConfig;
+import org.jruby.javasupport.JavaEmbedUtils;
+
+public class <%= java_class %> {
+  public static void debuggery(String message) {
+    System.err.println("DEBUGGERY:" + message); // JGBDEBUG
+  }
+
+  public static void main(String[] args) throws Exception {   
+    RubyInstanceConfig config = new RubyInstanceConfig();
+    config.setArgv(args);
+    Ruby runtime = JavaEmbedUtils.initialize(new ArrayList(0), config);
+    String mainRubyFile  = "main";
+    String runConfigFile = "run_configuration";
+
+    ArrayList<String> config_data = new ArrayList<String>();
+    try{
+      java.io.InputStream ins = Main.class.getClassLoader().getResourceAsStream(runConfigFile);
+      if (ins == null ) {
+        System.err.println("Did not find configuration file '" + runConfigFile + "', using defaults.");
+      } else {
+        config_data = getConfigFileContents(ins);
+      }
+    }
+    catch(IOException ioe) {
+      System.err.println("Error loading run configuration file '" + runConfigFile + "', using defaults: " + ioe);
+    }
+    catch(java.lang.NullPointerException npe) {
+      System.err.println("Error loading run configuration file '" + runConfigFile + "', using defaults: " + npe );
+    }
+
+    for(String line : config_data) {
+
+      String[] parts = line.split(":");
+      if("main_ruby_file".equals(parts[0].replaceAll(" ", ""))) {
+        mainRubyFile = parts[1].replaceAll(" ", "");
+      }
+
+      if("source_dirs".equals(parts[0].replaceAll(" ", ""))) {
+        String[] source_dirs = parts[1].split(";");
+
+        for(String s : parts[1].split(";") ){
+          String d = s.replaceAll(" ", "");
+          runtime.evalScriptlet( "$: << '"+d+"/'" );
+        }
+      }
+    }
+
+    runtime.evalScriptlet("require '" + mainRubyFile + "'");
+  }
+
+  public static URL getResource(String path) {
+      return Main.class.getClassLoader().getResource(path);
+  }
+
+  private static ArrayList<String> getConfigFileContents(InputStream input) throws IOException, java.lang.NullPointerException {
+    BufferedReader reader = new BufferedReader(new InputStreamReader(input));
+    String line;
+    ArrayList<String> contents = new ArrayList<String>();
+
+    while ((line = reader.readLine()) != null) {
+      contents.add(line);
+    }
+    reader.close();
+    return(contents);
+  }
+}


### PR DESCRIPTION
Doing this makes it a bit easier to hack on these files in the source code (especially if there is if/unless/each logic mixed in) and cleans up the individual bundler classes.

I've left the WebBundler alone since it's likely still being worked on but it should hopefully be pretty straight forward to change it to use this technique

I've also added a BundlerTemplate class which DRY's up the ERB related loading code a bit.  We can extend this class in the future to simplify evaluating the template (providing access to configuration data for instance) which should again make the Bundler classes simpler.
