### PR TITLE
Added new option 'source_jvm_version' for specifying javac source versio...

### DIFF
--- a/lib/rawr.rb
+++ b/lib/rawr.rb
@@ -107,11 +107,12 @@ namespace :rawr do
     target_file = File.join(CONFIG.compiled_java_classes_path, file_name.pathmap('%X.class'))
     COMPILED_JAVA_CLASSES.add(target_file)
 
+    source_jvm_version = [ '-source', CONFIG.source_jvm_version.to_s ]
     target_jvm_version = [ '-target', CONFIG.target_jvm_version.to_s ]
     classpath = ['-cp', (CONFIG.classpath + CONFIG.source_dirs).join(delimiter) ]
     sourcepath = [ '-sourcepath', CONFIG.source_dirs.join(delimiter) ]
     outdir = [ '-d', CONFIG.compiled_java_classes_path ]
-    base_javac_args = target_jvm_version + classpath + sourcepath + outdir
+    base_javac_args = source_jvm_version + target_jvm_version + classpath + sourcepath + outdir
 
     file target_file => [ source_file, CONFIG.compiled_java_classes_path ] do
       sh 'javac', *(base_javac_args + [source_file])


### PR DESCRIPTION
...n. javac does not allow target version to be lower than the source version, which by default is the level of the specific javac used. When using 1.7 javac to compile to target 1.6, javac does not allow it. This new option would make this possible.
