### PR TITLE
Call terminate after running script so at_exit is handled

### DIFF
--- a/lib/rawr/templates/java_runner/runner.java.erb
+++ b/lib/rawr/templates/java_runner/runner.java.erb
@@ -65,6 +65,7 @@ public class <%= java_class %> {
     }
 
     runtime.evalScriptlet("require '" + mainRubyFile + "'");
+    JavaEmbedUtils.terminate(runtime);
   }
 
   public static URL getResource(String path) {


### PR DESCRIPTION
at_exit is not called, terminating the runtime will cause it to be called. This will fix jruby apps using commander (which calls run! at exit)
